### PR TITLE
Agregar tests para palabras que no son palíndromos 

### DIFF
--- a/tests/test_palindrome.py
+++ b/tests/test_palindrome.py
@@ -11,3 +11,8 @@ class TestPalindrome(unittest.TestCase):
         self.assertTrue(is_palindrome("A man, a plan, a canal: Panama"))
         self.assertTrue(is_palindrome("Was it a car or a cat I saw?"))
         self.assertTrue(is_palindrome("No lemon, no melon"))
+    
+    def test_non_palindromes(self):
+        self.assertFalse(is_palindrome("hello"))
+        self.assertFalse(is_palindrome("python"))
+        self.assertFalse(is_palindrome("This is not a palindrome"))

--- a/tests/test_palindrome.py
+++ b/tests/test_palindrome.py
@@ -1,0 +1,13 @@
+import unittest
+from src.palindrome import is_palindrome
+
+class TestPalindrome(unittest.TestCase):
+    def test_simple_palindromes(self):
+        self.assertTrue(is_palindrome("madam"))
+        self.assertTrue(is_palindrome("racecar"))
+        self.assertTrue(is_palindrome("level"))
+
+    def test_phrase_palindromes(self):
+        self.assertTrue(is_palindrome("A man, a plan, a canal: Panama"))
+        self.assertTrue(is_palindrome("Was it a car or a cat I saw?"))
+        self.assertTrue(is_palindrome("No lemon, no melon"))


### PR DESCRIPTION
Se agregaron pruebas para verificar que palabras como "hola", "perro", y "casa" no sean reconocidas como palíndromos. 
Close #4 