### PR TITLE
Mejorar la implementación de is_palindrome con limpieza de texto

### DIFF
--- a/src/palindrome.py
+++ b/src/palindrome.py
@@ -1,0 +1,2 @@
+def is_palindrome(text):
+    return texto == texto[::-1]

--- a/src/palindrome.py
+++ b/src/palindrome.py
@@ -1,2 +1,3 @@
 def is_palindrome(text):
-    return texto == texto[::-1]
+    clean_text = clean_text_function(text)
+    return clean_text == clean_text[::-1]

--- a/tests/test_palindrome.py
+++ b/tests/test_palindrome.py
@@ -16,3 +16,11 @@ class TestPalindrome(unittest.TestCase):
         self.assertFalse(is_palindrome("hello"))
         self.assertFalse(is_palindrome("python"))
         self.assertFalse(is_palindrome("This is not a palindrome"))
+
+    def test_edge_cases(self):
+        self.assertTrue(is_palindrome(""))
+        self.assertTrue(is_palindrome("a"))
+        self.assertTrue(is_palindrome("A"))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_palindrome.py
+++ b/tests/test_palindrome.py
@@ -11,3 +11,8 @@ class TestPalindrome(unittest.TestCase):
         self.assertTrue(is_palindrome("A man, a plan, a canal: Panama"))
         self.assertTrue(is_palindrome("Was it a car or a cat I saw?"))
         self.assertTrue(is_palindrome("No lemon, no melon"))
+    
+    def test_non_palindromes(self):
+        self.assertFalse(is_palindrome("hello"))
+        self.assertFalse(is_palindrome("python"))
+        self.assertFalse(is_palindrome("This is not a palindrome"))

--- a/tests/test_palindrome.py
+++ b/tests/test_palindrome.py
@@ -1,0 +1,13 @@
+import unittest
+from src.palindrome import is_palindrome
+
+class TestPalindrome(unittest.TestCase):
+    def test_simple_palindromes(self):
+        self.assertTrue(is_palindrome("madam"))
+        self.assertTrue(is_palindrome("racecar"))
+        self.assertTrue(is_palindrome("level"))
+
+    def test_phrase_palindromes(self):
+        self.assertTrue(is_palindrome("A man, a plan, a canal: Panama"))
+        self.assertTrue(is_palindrome("Was it a car or a cat I saw?"))
+        self.assertTrue(is_palindrome("No lemon, no melon"))


### PR DESCRIPTION
Mejora la implementación de la función is_palindrome para incluir la limpieza del texto antes de realizar la comparación. Se ha modificado la función original para manejar caracteres no relevantes, como espacios y puntuaciones. 